### PR TITLE
修复删除Skills.lyx就无法编译错误

### DIFF
--- a/ustcsetup.tex
+++ b/ustcsetup.tex
@@ -37,6 +37,9 @@
 % SI 量和单位
 \usepackage{siunitx}
 
+% 添加 prettyref 包
+\usepackage{prettyref}
+
 % 参考文献使用 BibTeX + natbib 宏包
 % 顺序编码制
 \usepackage[sort]{natbib}


### PR DESCRIPTION
目前的版本删除Skills.lyx 便无法编译，经过测试发现是遗漏prettyref包的原因